### PR TITLE
Improve hex list panel UX: scroll to hex and fix positioning

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1299,10 +1299,12 @@ body {
    HEX LIST PANEL
    ============================================ */
 .hex-list-panel {
-  position: absolute;
+  position: fixed;
   top: 60px;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
   width: 400px;
   max-width: calc(100vw - 40px);
   max-height: calc(100vh - 100px);
@@ -1313,6 +1315,12 @@ body {
   z-index: 1000;
   display: flex;
   flex-direction: column;
+}
+
+/* Adjust hex list panel position when sidebar is open */
+.sidebar-open .hex-list-panel {
+  right: var(--sidebar-width);
+  max-width: calc(100vw - var(--sidebar-width) - 40px);
 }
 
 .hex-list-panel .panel-header {


### PR DESCRIPTION
- Add scrollToHex function that smoothly scrolls map to center on a hex
- Call scrollToHex when selecting a hex from the list panel
- Change hex list panel to position: fixed so it stays on screen
- Center panel relative to map area, accounting for sidebar state
- Add sidebar-open class to app-container for CSS targeting