### PR TITLE
Add Region system and bulk faction/region assignment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -201,7 +201,38 @@ function App() {
       updatedAt: new Date().toISOString(),
     });
   }, [currentMap, multiSelectedCoords]);
-  
+
+  const handleBulkAddToFaction = useCallback((factionId: string) => {
+    if (!currentMap || multiSelectedCoords.length === 0) return;
+
+    const faction = currentMap.factions.find(f => f.id === factionId);
+    if (!faction) return;
+
+    // Get existing domain hex keys
+    const existingKeys = new Set(faction.domainHexes.map(h => coordToKey(h)));
+
+    // Add new coords that aren't already in the domain
+    const newDomainHexes = [...faction.domainHexes];
+    for (const coord of multiSelectedCoords) {
+      const key = coordToKey(coord);
+      if (!existingKeys.has(key)) {
+        newDomainHexes.push(coord);
+        existingKeys.add(key);
+      }
+    }
+
+    const updatedFaction = { ...faction, domainHexes: newDomainHexes };
+    const newFactions = currentMap.factions.map(f =>
+      f.id === factionId ? updatedFaction : f
+    );
+
+    setCurrentMap({
+      ...currentMap,
+      factions: newFactions,
+      updatedAt: new Date().toISOString(),
+    });
+  }, [currentMap, multiSelectedCoords]);
+
   // Settings
   const handleSettingsChange = useCallback((updates: Partial<CampaignSettings>) => {
     if (!currentMap) return;
@@ -614,9 +645,11 @@ function App() {
                 gridConfig={currentMap.gridConfig}
                 map={currentMap}
                 customTerrainTypes={currentMap.settings.customTerrainTypes}
+                factions={currentMap.factions}
                 onBulkSetTerrain={handleBulkSetTerrain}
                 onBulkAddTags={handleBulkAddTags}
                 onBulkSetExplored={handleBulkSetExplored}
+                onBulkAddToFaction={handleBulkAddToFaction}
                 onClearSelection={handleClearSelection}
               />
             )}

--- a/src/components/MultiSelectPanel.tsx
+++ b/src/components/MultiSelectPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react';
-import type { HexCoord, TerrainType, GridConfig, CampaignMap } from '@/lib/types';
+import type { HexCoord, TerrainType, GridConfig, CampaignMap, Faction } from '@/lib/types';
 import { DEFAULT_TERRAIN_TYPES } from '@/lib/types';
 import { axialToOffset } from '@/lib/hexUtils';
 
@@ -8,9 +8,11 @@ interface MultiSelectPanelProps {
   gridConfig: GridConfig;
   map: CampaignMap;
   customTerrainTypes: TerrainType[];
+  factions: Faction[];
   onBulkSetTerrain: (terrainId: string) => void;
   onBulkAddTags: (tags: string[]) => void;
   onBulkSetExplored: (explored: boolean) => void;
+  onBulkAddToFaction: (factionId: string) => void;
   onClearSelection: () => void;
 }
 
@@ -19,13 +21,19 @@ const MultiSelectPanel: React.FC<MultiSelectPanelProps> = ({
   gridConfig,
   map,
   customTerrainTypes,
+  factions,
   onBulkSetTerrain,
   onBulkAddTags,
   onBulkSetExplored,
+  onBulkAddToFaction,
   onClearSelection,
 }) => {
   const [selectedTerrain, setSelectedTerrain] = useState('');
   const [selectedTag, setSelectedTag] = useState('');
+
+  // Separate factions and regions
+  const actualFactions = useMemo(() => factions.filter(f => f.type !== 'region'), [factions]);
+  const regions = useMemo(() => factions.filter(f => f.type === 'region'), [factions]);
 
   const allTerrains = [...DEFAULT_TERRAIN_TYPES, ...customTerrainTypes];
 
@@ -172,6 +180,52 @@ const MultiSelectPanel: React.FC<MultiSelectPanelProps> = ({
               </button>
             </div>
           </div>
+
+          {/* Add to Faction */}
+          {actualFactions.length > 0 && (
+            <div className="form-group">
+              <label className="form-label">Add to Faction</label>
+              <select
+                className="form-select"
+                value=""
+                onChange={(e) => {
+                  if (e.target.value) {
+                    onBulkAddToFaction(e.target.value);
+                  }
+                }}
+              >
+                <option value="">Select faction...</option>
+                {actualFactions.map(f => (
+                  <option key={f.id} value={f.id}>
+                    {f.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {/* Add to Region */}
+          {regions.length > 0 && (
+            <div className="form-group">
+              <label className="form-label">Add to Region</label>
+              <select
+                className="form-select"
+                value=""
+                onChange={(e) => {
+                  if (e.target.value) {
+                    onBulkAddToFaction(e.target.value);
+                  }
+                }}
+              >
+                <option value="">Select region...</option>
+                {regions.map(r => (
+                  <option key={r.id} value={r.id}>
+                    {r.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
         </div>
       </div>
       

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -84,7 +84,8 @@ const Toolbar: React.FC<ToolbarProps> = ({
     explored: map.hexes.filter(h => h.campaignData?.explored).length,
     withFeatures: map.hexes.filter(h => h.featureType).length,
     withTags: map.hexes.filter(h => h.campaignData?.tags?.length).length,
-    factions: map.factions?.length ?? 0,
+    factions: map.factions?.filter(f => f.type !== 'region').length ?? 0,
+    regions: map.factions?.filter(f => f.type === 'region').length ?? 0,
   } : null;
   
   return (
@@ -192,7 +193,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
               onClick={() => onStatsClick('all')}
               title="Total hexes - click to view all"
             >
-              🗺 {stats.hexes}
+              ⬢ {stats.hexes}
             </button>
             <button 
               className="toolbar-stat-btn"
@@ -232,6 +233,13 @@ const Toolbar: React.FC<ToolbarProps> = ({
               title="Factions - click to manage"
             >
               👥 {stats.factions}
+            </button>
+            <button
+              className="toolbar-stat-btn"
+              onClick={() => onStatsClick('factions')}
+              title="Regions - click to manage"
+            >
+              🗺 {stats.regions}
             </button>
           </div>
         )}

--- a/src/lib/generator/politicalGenerator.ts
+++ b/src/lib/generator/politicalGenerator.ts
@@ -170,6 +170,7 @@ export function createFactionFromSettlement(
   return {
     id: generateFactionId(),
     name: settlementName,
+    type: 'faction',
     color: factionColor,
     sourceHexCoord: centerCoord,
     domainHexes: domain.hexes,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -227,19 +227,22 @@ export interface FactionRelationship {
   status: FactionRelationshipStatus;
 }
 
+export type FactionType = 'faction' | 'region';
+
 export interface Faction {
   id: string;
   name: string;
+  type: FactionType;
   color?: string;
   sourceHexCoord: HexCoord;
   domainHexes: HexCoord[];
   relationships: FactionRelationship[];
-  
+
   // Arbitrary notes - key-value pairs for user content
   notes?: Record<string, string>;
   // Track which default notes the user has explicitly deleted
   deletedNotes?: string[];
-  
+
   customFields?: Record<string, string | number | boolean>;
 }
 


### PR DESCRIPTION
- Add FactionType ('faction' | 'region') to distinguish political groups from geographic areas
- Update FactionPanel with type selector and separate sections for factions vs regions
- Only show Relationships accordion for factions (not regions)
- Update HexDetailPanel to display factions and regions separately
- Add separate toolbar stats for factions and regions
- Change "all hexes" icon from 🗺 to ⬢ to differentiate from regions
- Add "Add to Faction" and "Add to Region" dropdowns to MultiSelectPanel for bulk territory assignment