### PR TITLE
Add custom color picker to faction/region dialogs

### DIFF
--- a/src/components/FactionPanel.tsx
+++ b/src/components/FactionPanel.tsx
@@ -333,6 +333,26 @@ const FactionPanel: React.FC<FactionPanelProps> = ({
                   />
                 ))}
               </div>
+              <div className="color-picker-row">
+                <input
+                  type="color"
+                  className="color-picker-input"
+                  value={newColor}
+                  onChange={e => setNewColor(e.target.value)}
+                />
+                <input
+                  type="text"
+                  className="form-input color-hex-input"
+                  value={newColor}
+                  onChange={e => {
+                    const val = e.target.value;
+                    if (/^#[0-9A-Fa-f]{0,6}$/.test(val)) {
+                      setNewColor(val);
+                    }
+                  }}
+                  placeholder="#000000"
+                />
+              </div>
             </div>
             
             <p className="text-sm text-muted">
@@ -430,6 +450,26 @@ const FactionPanel: React.FC<FactionPanelProps> = ({
                         onClick={() => handleUpdateFaction({ color })}
                       />
                     ))}
+                  </div>
+                  <div className="color-picker-row">
+                    <input
+                      type="color"
+                      className="color-picker-input"
+                      value={selectedFaction.color || '#808080'}
+                      onChange={e => handleUpdateFaction({ color: e.target.value })}
+                    />
+                    <input
+                      type="text"
+                      className="form-input color-hex-input"
+                      value={selectedFaction.color || ''}
+                      onChange={e => {
+                        const val = e.target.value;
+                        if (/^#[0-9A-Fa-f]{0,6}$/.test(val)) {
+                          handleUpdateFaction({ color: val });
+                        }
+                      }}
+                      placeholder="#000000"
+                    />
                   </div>
                 </div>
               </Accordion>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1226,6 +1226,38 @@ body {
   box-shadow: 0 0 0 2px var(--bg-primary);
 }
 
+.color-picker-row {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+  align-items: center;
+}
+
+.color-picker-input {
+  width: 40px;
+  height: 32px;
+  padding: 2px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
+  cursor: pointer;
+}
+
+.color-picker-input::-webkit-color-swatch-wrapper {
+  padding: 2px;
+}
+
+.color-picker-input::-webkit-color-swatch {
+  border-radius: var(--radius-xs);
+  border: none;
+}
+
+.color-hex-input {
+  flex: 1;
+  font-family: monospace;
+  text-transform: uppercase;
+}
+
 .color-dot {
   width: 12px;
   height: 12px;


### PR DESCRIPTION
Add native color picker and hex input field to faction/region creation and edit forms, allowing users to select any color instead of only the 20 preset options.