### PR TITLE
Fix regional terrain generation and race condition with faction creation

### DIFF
--- a/src/lib/generator/mapGenerator.ts
+++ b/src/lib/generator/mapGenerator.ts
@@ -230,8 +230,11 @@ export function generateRegion(
   // Get 19-hex spiral coords
   const coords = generate19HexRegion(centerCoord);
   
-  // Filter out coords that already have terrain (unless we want to overwrite)
-  const targetCoords = coords.filter(c => !existingTerrain.has(coordToKey(c)));
+  // Filter out coords that already have terrain (keep 'unknown' terrain for generation)
+  const targetCoords = coords.filter(c => {
+    const terrainId = existingTerrain.get(coordToKey(c));
+    return !terrainId || terrainId === 'unknown';
+  });
   
   // Generate each hex in spiral order
   for (let i = 0; i < targetCoords.length; i++) {


### PR DESCRIPTION
Fixed multiple bugs in the regional generation system:
1. **Terrain generation not working**: The `generateRegion` function was 
   filtering out all hexes that had ANY terrain in the existingTerrain map,
   including 'unknown' terrain. Changed the filter to only skip hexes with
   actual terrain (not 'unknown'), allowing generation on empty hexes.
2. **Race condition causing hex updates to be lost**: When generating regions
   with factions enabled, calling `onBulkHexUpdate()` followed by multiple
   `onAddFaction()` calls caused a race condition. Each `onAddFaction` spread
   `...currentMap` which included stale hex data, overwriting the hex updates
   from `onBulkHexUpdate`. This resulted in factions being created but terrain
   and features not appearing on the map.
   
   Fixed by adding `handleBulkHexUpdateWithFactions()` that applies hex updates
   and faction additions in a single atomic state update.
3. **Added overwrite controls**: Added checkboxes to allow users to optionally
   overwrite existing terrain and features during regional generation, giving
   more control over the generation process.
4. **Improved faction relationship generation**: Collected all new factions
   first, then generated relationships between them and existing factions
   before applying state updates, ensuring correct faction relationships.