### PR TITLE
Add image export for VTT use

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "campaign-mapper",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Hex Map Campaign Manager for TTRPGs - overlay images, generate terrain, track campaigns",
   "type": "module",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,8 @@ import {
   loadAppSettings,
 } from '@/lib/storage';
 
-import HexMap from '@/components/HexMap';
+import HexMap, { type HexMapHandle } from '@/components/HexMap';
+import { exportMapAsImage } from '@/lib/imageExport';
 import HexDetailPanel from '@/components/HexDetailPanel';
 import MultiSelectPanel from '@/components/MultiSelectPanel';
 import SettingsPanel from '@/components/SettingsPanel';
@@ -57,6 +58,9 @@ function App() {
 
   // Ref for map container (for scrolling to hexes)
   const mapContainerRef = useRef<HTMLDivElement>(null);
+
+  // Ref for HexMap (for image export)
+  const hexMapRef = useRef<HexMapHandle>(null);
 
   // Load last map on mount
   useEffect(() => {
@@ -373,6 +377,25 @@ function App() {
       }
     }
   }, [currentMap]);
+
+  const handleExportMapAsImage = useCallback(async () => {
+    if (!currentMap || !hexMapRef.current) return;
+
+    const svg = hexMapRef.current.getSvgElement();
+    if (!svg) {
+      alert('Unable to export: map not ready');
+      return;
+    }
+
+    try {
+      await exportMapAsImage(svg, {
+        backgroundImage: hexMapRef.current.getBackgroundImage(),
+        filename: currentMap.name,
+      });
+    } catch (err) {
+      alert('Failed to export image: ' + (err as Error).message);
+    }
+  }, [currentMap]);
   
   const handleImportMap = useCallback(() => {
     const input = document.createElement('input');
@@ -598,6 +621,7 @@ function App() {
           onNewMap={handleNewMap}
           onOpenMap={handleOpenMap}
           onExportMap={handleExportMap}
+          onExportMapAsImage={handleExportMapAsImage}
           onImportMap={handleImportMap}
           onOpenSettings={handleOpenSettings}
           onMapNameChange={handleMapNameChange}
@@ -612,6 +636,7 @@ function App() {
           {currentMap ? (
             <>
               <HexMap
+                ref={hexMapRef}
                 hexes={currentMap.hexes}
                 gridConfig={currentMap.gridConfig}
                 settings={currentMap.settings}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
-import type { 
-  CampaignMap, 
-  HexCoord, 
+import type {
+  CampaignMap,
+  HexCoord,
   Hex,
   Faction,
   CampaignSettings,
   GridConfig,
   MapMode,
+  ImageOverlay,
 } from '@/lib/types';
 import { coordToKey } from '@/lib/types';
 import {
@@ -253,7 +254,16 @@ function App() {
     if (!currentMap) return;
     setCurrentMap(updateGridConfig(currentMap, updates));
   }, [currentMap]);
-  
+
+  const handleImageOverlayChange = useCallback((updates: Partial<ImageOverlay>) => {
+    if (!currentMap || !currentMap.imageOverlay) return;
+    setCurrentMap({
+      ...currentMap,
+      imageOverlay: { ...currentMap.imageOverlay, ...updates },
+      updatedAt: new Date().toISOString(),
+    });
+  }, [currentMap]);
+
   // Map operations
   const handleNewMap = useCallback(() => {
     setShowNewMapDialog(true);
@@ -734,8 +744,10 @@ function App() {
               <SettingsPanel
                 settings={currentMap.settings}
                 gridConfig={currentMap.gridConfig}
+                imageOverlay={currentMap.imageOverlay}
                 onSettingsChange={handleSettingsChange}
                 onGridConfigChange={handleGridConfigChange}
+                onImageOverlayChange={handleImageOverlayChange}
                 onClose={handleCloseSidebar}
               />
             )}
@@ -772,6 +784,9 @@ function App() {
         isOpen={showExportDialog}
         mapName={currentMap?.name || 'map'}
         hasBackgroundImage={!!currentMap?.imageOverlay?.src}
+        backgroundImageVisible={currentMap?.imageOverlay?.visible}
+        backgroundImageOpacity={currentMap?.imageOverlay?.opacity}
+        mapSettings={currentMap?.settings}
         onClose={() => setShowExportDialog(false)}
         onExport={handleExportWithOptions}
       />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,8 @@ import {
 } from '@/lib/storage';
 
 import HexMap, { type HexMapHandle } from '@/components/HexMap';
-import { exportMapAsImage } from '@/lib/imageExport';
+import { exportMapAsImage, type ImageExportOptions } from '@/lib/imageExport';
+import ExportImageDialog from '@/components/ExportImageDialog';
 import HexDetailPanel from '@/components/HexDetailPanel';
 import MultiSelectPanel from '@/components/MultiSelectPanel';
 import SettingsPanel from '@/components/SettingsPanel';
@@ -53,6 +54,7 @@ function App() {
   const [sidebarView, setSidebarView] = useState<SidebarView>('none');
   const [showNewMapDialog, setShowNewMapDialog] = useState(false);
   const [showMapList, setShowMapList] = useState(false);
+  const [showExportDialog, setShowExportDialog] = useState(false);
   const [zoom, setZoom] = useState(1);
   const [hexListFilter, setHexListFilter] = useState<StatsFilterType | null>(null);
 
@@ -378,7 +380,12 @@ function App() {
     }
   }, [currentMap]);
 
-  const handleExportMapAsImage = useCallback(async () => {
+  const handleExportMapAsImage = useCallback(() => {
+    if (!currentMap) return;
+    setShowExportDialog(true);
+  }, [currentMap]);
+
+  const handleExportWithOptions = useCallback(async (options: ImageExportOptions) => {
     if (!currentMap || !hexMapRef.current) return;
 
     const svg = hexMapRef.current.getSvgElement();
@@ -389,9 +396,10 @@ function App() {
 
     try {
       await exportMapAsImage(svg, {
+        ...options,
         backgroundImage: hexMapRef.current.getBackgroundImage(),
-        filename: currentMap.name,
       });
+      setShowExportDialog(false);
     } catch (err) {
       alert('Failed to export image: ' + (err as Error).message);
     }
@@ -759,7 +767,15 @@ function App() {
         onClose={() => setShowNewMapDialog(false)}
         onCreate={handleCreateMap}
       />
-      
+
+      <ExportImageDialog
+        isOpen={showExportDialog}
+        mapName={currentMap?.name || 'map'}
+        hasBackgroundImage={!!currentMap?.imageOverlay?.src}
+        onClose={() => setShowExportDialog(false)}
+        onExport={handleExportWithOptions}
+      />
+
       {/* Map List Modal */}
       {showMapList && (
         <div className="modal-overlay" onClick={() => setShowMapList(false)}>

--- a/src/components/ExportImageDialog.tsx
+++ b/src/components/ExportImageDialog.tsx
@@ -1,0 +1,277 @@
+import React, { useState, useCallback, useEffect } from 'react';
+
+export type ImageFormat = 'png' | 'jpeg' | 'webp';
+
+export interface ImageExportOptions {
+  filename: string;
+  format: ImageFormat;
+  quality: number;
+  includeBackground: boolean;
+  backgroundOpacity: number;
+  includeHexOutlines: boolean;
+  hexOutlineOpacity: number;
+  hexFillOpacity: number;
+  includeCoordinates: boolean;
+  includeFeatureMarkers: boolean;
+  includeTerrainSymbols: boolean;
+  scale: number;
+}
+
+interface ExportImageDialogProps {
+  isOpen: boolean;
+  mapName: string;
+  hasBackgroundImage: boolean;
+  onClose: () => void;
+  onExport: (options: ImageExportOptions) => void;
+}
+
+const DEFAULT_OPTIONS: ImageExportOptions = {
+  filename: '',
+  format: 'png',
+  quality: 85,
+  includeBackground: true,
+  backgroundOpacity: 100,
+  includeHexOutlines: true,
+  hexOutlineOpacity: 30,
+  hexFillOpacity: 50,
+  includeCoordinates: true,
+  includeFeatureMarkers: true,
+  includeTerrainSymbols: true,
+  scale: 1,
+};
+
+const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
+  isOpen,
+  mapName,
+  hasBackgroundImage,
+  onClose,
+  onExport,
+}) => {
+  const [options, setOptions] = useState<ImageExportOptions>({
+    ...DEFAULT_OPTIONS,
+    filename: mapName,
+  });
+
+  // Reset filename when map name changes or dialog opens
+  useEffect(() => {
+    if (isOpen) {
+      setOptions(prev => ({ ...prev, filename: mapName }));
+    }
+  }, [isOpen, mapName]);
+
+  const handleChange = useCallback(<K extends keyof ImageExportOptions>(
+    key: K,
+    value: ImageExportOptions[K]
+  ) => {
+    setOptions(prev => ({ ...prev, [key]: value }));
+  }, []);
+
+  const handleExport = useCallback(() => {
+    onExport(options);
+  }, [options, onExport]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2 className="modal-title">Export as Image</h2>
+          <button className="modal-close" onClick={onClose}>×</button>
+        </div>
+
+        <div className="modal-content">
+          {/* Filename */}
+          <div className="form-group">
+            <label className="form-label">Filename</label>
+            <div className="flex gap-2 items-center">
+              <input
+                type="text"
+                className="form-input"
+                value={options.filename}
+                onChange={e => handleChange('filename', e.target.value)}
+                placeholder="map_export"
+              />
+              <span className="text-muted">.{options.format === 'jpeg' ? 'jpg' : options.format}</span>
+            </div>
+          </div>
+
+          {/* Format & Quality */}
+          <div className="form-group">
+            <label className="form-label">Format</label>
+            <div className="flex gap-2 mb-2">
+              {(['jpeg', 'png', 'webp'] as const).map(fmt => (
+                <button
+                  key={fmt}
+                  className={`btn btn-sm ${options.format === fmt ? 'btn-primary' : 'btn-secondary'}`}
+                  onClick={() => handleChange('format', fmt)}
+                >
+                  {fmt.toUpperCase()}
+                </button>
+              ))}
+            </div>
+            {options.format !== 'png' && (
+              <div className="panel-row">
+                <span className="text-sm">Quality: {options.quality}%</span>
+                <input
+                  type="range"
+                  className="form-range"
+                  min="10"
+                  max="100"
+                  value={options.quality}
+                  onChange={e => handleChange('quality', parseInt(e.target.value))}
+                  style={{ width: '120px' }}
+                />
+              </div>
+            )}
+            <p className="text-muted text-sm mt-1">
+              {options.format === 'png' && 'Lossless, larger file size'}
+              {options.format === 'jpeg' && 'Smaller file size, good for photos'}
+              {options.format === 'webp' && 'Modern format, smallest size'}
+            </p>
+          </div>
+
+          {/* Background Image Section */}
+          {hasBackgroundImage && (
+            <>
+              <div className="form-group">
+                <label className="form-label">Background Image</label>
+                <div className="panel-row mb-2">
+                  <span className="text-sm">Include Background</span>
+                  <button
+                    className={`btn btn-sm ${options.includeBackground ? 'btn-primary' : 'btn-secondary'}`}
+                    onClick={() => handleChange('includeBackground', !options.includeBackground)}
+                  >
+                    {options.includeBackground ? 'Yes' : 'No'}
+                  </button>
+                </div>
+                {options.includeBackground && (
+                  <div className="panel-row">
+                    <span className="text-sm">Opacity: {options.backgroundOpacity}%</span>
+                    <input
+                      type="range"
+                      className="form-range"
+                      min="0"
+                      max="100"
+                      value={options.backgroundOpacity}
+                      onChange={e => handleChange('backgroundOpacity', parseInt(e.target.value))}
+                      style={{ width: '120px' }}
+                    />
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+
+          {/* Hex Rendering Section */}
+          <div className="form-group">
+            <label className="form-label">Hex Rendering</label>
+
+            <div className="panel-row mb-2">
+              <span className="text-sm">Show Hex Outlines</span>
+              <button
+                className={`btn btn-sm ${options.includeHexOutlines ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => handleChange('includeHexOutlines', !options.includeHexOutlines)}
+              >
+                {options.includeHexOutlines ? 'Yes' : 'No'}
+              </button>
+            </div>
+
+            {options.includeHexOutlines && (
+              <div className="panel-row mb-2">
+                <span className="text-sm">Outline Opacity: {options.hexOutlineOpacity}%</span>
+                <input
+                  type="range"
+                  className="form-range"
+                  min="0"
+                  max="100"
+                  value={options.hexOutlineOpacity}
+                  onChange={e => handleChange('hexOutlineOpacity', parseInt(e.target.value))}
+                  style={{ width: '120px' }}
+                />
+              </div>
+            )}
+
+            <div className="panel-row">
+              <span className="text-sm">Hex Fill Opacity: {options.hexFillOpacity}%</span>
+              <input
+                type="range"
+                className="form-range"
+                min="0"
+                max="100"
+                value={options.hexFillOpacity}
+                onChange={e => handleChange('hexFillOpacity', parseInt(e.target.value))}
+                style={{ width: '120px' }}
+              />
+            </div>
+          </div>
+
+          {/* Labels & Markers Section */}
+          <div className="form-group">
+            <label className="form-label">Labels & Markers</label>
+
+            <div className="panel-row mb-2">
+              <span className="text-sm">Hex Coordinates</span>
+              <button
+                className={`btn btn-sm ${options.includeCoordinates ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => handleChange('includeCoordinates', !options.includeCoordinates)}
+              >
+                {options.includeCoordinates ? 'Show' : 'Hide'}
+              </button>
+            </div>
+
+            <div className="panel-row mb-2">
+              <span className="text-sm">Terrain Symbols</span>
+              <button
+                className={`btn btn-sm ${options.includeTerrainSymbols ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => handleChange('includeTerrainSymbols', !options.includeTerrainSymbols)}
+              >
+                {options.includeTerrainSymbols ? 'Show' : 'Hide'}
+              </button>
+            </div>
+
+            <div className="panel-row">
+              <span className="text-sm">Feature Markers</span>
+              <button
+                className={`btn btn-sm ${options.includeFeatureMarkers ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => handleChange('includeFeatureMarkers', !options.includeFeatureMarkers)}
+              >
+                {options.includeFeatureMarkers ? 'Show' : 'Hide'}
+              </button>
+            </div>
+          </div>
+
+          {/* Resolution Section */}
+          <div className="form-group">
+            <label className="form-label">Resolution</label>
+            <div className="flex gap-2 flex-wrap">
+              {[0.25, 0.5, 1, 2, 3].map(scale => (
+                <button
+                  key={scale}
+                  className={`btn btn-sm ${options.scale === scale ? 'btn-primary' : 'btn-secondary'}`}
+                  onClick={() => handleChange('scale', scale)}
+                >
+                  {scale}x
+                </button>
+              ))}
+            </div>
+            <p className="text-muted text-sm mt-1">
+              Higher resolution = larger file size
+            </p>
+          </div>
+        </div>
+
+        <div className="modal-footer">
+          <button className="btn btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button className="btn btn-primary" onClick={handleExport}>
+            Export PNG
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExportImageDialog;

--- a/src/components/ExportImageDialog.tsx
+++ b/src/components/ExportImageDialog.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
+import type { CampaignSettings } from '@/lib/types';
 
 export type ImageFormat = 'png' | 'jpeg' | 'webp';
 
@@ -8,12 +9,14 @@ export interface ImageExportOptions {
   quality: number;
   includeBackground: boolean;
   backgroundOpacity: number;
-  includeHexOutlines: boolean;
-  hexOutlineOpacity: number;
+  showGrid: boolean;
+  gridOpacity: number;
   hexFillOpacity: number;
-  includeCoordinates: boolean;
-  includeFeatureMarkers: boolean;
-  includeTerrainSymbols: boolean;
+  showTerrainColors: boolean;
+  showCoordinates: boolean;
+  showFeatureMarkers: boolean;
+  showFactionTerritories: boolean;
+  showFogOfWar: boolean;
   scale: number;
 }
 
@@ -21,6 +24,9 @@ interface ExportImageDialogProps {
   isOpen: boolean;
   mapName: string;
   hasBackgroundImage: boolean;
+  backgroundImageVisible?: boolean;
+  backgroundImageOpacity?: number;
+  mapSettings?: CampaignSettings;
   onClose: () => void;
   onExport: (options: ImageExportOptions) => void;
 }
@@ -31,12 +37,14 @@ const DEFAULT_OPTIONS: ImageExportOptions = {
   quality: 85,
   includeBackground: true,
   backgroundOpacity: 100,
-  includeHexOutlines: true,
-  hexOutlineOpacity: 30,
+  showGrid: true,
+  gridOpacity: 30,
   hexFillOpacity: 50,
-  includeCoordinates: true,
-  includeFeatureMarkers: true,
-  includeTerrainSymbols: true,
+  showTerrainColors: true,
+  showCoordinates: true,
+  showFeatureMarkers: true,
+  showFactionTerritories: true,
+  showFogOfWar: false,
   scale: 1,
 };
 
@@ -44,6 +52,9 @@ const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
   isOpen,
   mapName,
   hasBackgroundImage,
+  backgroundImageVisible,
+  backgroundImageOpacity,
+  mapSettings,
   onClose,
   onExport,
 }) => {
@@ -66,6 +77,23 @@ const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
     setOptions(prev => ({ ...prev, [key]: value }));
   }, []);
 
+  const handleUseMapSettings = useCallback(() => {
+    if (!mapSettings) return;
+    setOptions(prev => ({
+      ...prev,
+      includeBackground: backgroundImageVisible ?? true,
+      backgroundOpacity: Math.round((backgroundImageOpacity ?? 1) * 100),
+      showGrid: mapSettings.showGrid,
+      gridOpacity: Math.round((mapSettings.gridOpacity ?? 0.3) * 100),
+      hexFillOpacity: Math.round(mapSettings.hexFillOpacity * 100),
+      showTerrainColors: mapSettings.showTerrainColors,
+      showCoordinates: mapSettings.showCoordinates,
+      showFeatureMarkers: mapSettings.showDataIndicators,
+      showFactionTerritories: mapSettings.showFactionTerritories,
+      showFogOfWar: mapSettings.showExploredStatus,
+    }));
+  }, [mapSettings, backgroundImageVisible, backgroundImageOpacity]);
+
   const handleExport = useCallback(() => {
     onExport(options);
   }, [options, onExport]);
@@ -81,6 +109,21 @@ const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
         </div>
 
         <div className="modal-content">
+          {/* Quick settings */}
+          {mapSettings && (
+            <div className="form-group">
+              <button
+                className="btn btn-secondary btn-sm"
+                onClick={handleUseMapSettings}
+              >
+                Use Map Display Settings
+              </button>
+              <p className="text-muted text-sm mt-1">
+                Copy current visibility settings from the map
+              </p>
+            </div>
+          )}
+
           {/* Filename */}
           <div className="form-group">
             <label className="form-label">Filename</label>
@@ -168,42 +211,29 @@ const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
             <label className="form-label">Hex Rendering</label>
 
             <div className="panel-row mb-2">
-              <span className="text-sm">Show Hex Outlines</span>
+              <span className="text-sm">Show Grid</span>
               <button
-                className={`btn btn-sm ${options.includeHexOutlines ? 'btn-primary' : 'btn-secondary'}`}
-                onClick={() => handleChange('includeHexOutlines', !options.includeHexOutlines)}
+                className={`btn btn-sm ${options.showGrid ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => handleChange('showGrid', !options.showGrid)}
               >
-                {options.includeHexOutlines ? 'Yes' : 'No'}
+                {options.showGrid ? 'On' : 'Off'}
               </button>
             </div>
 
-            {options.includeHexOutlines && (
-              <div className="panel-row mb-2">
-                <span className="text-sm">Outline Opacity: {options.hexOutlineOpacity}%</span>
+            {options.showGrid && (
+              <div className="panel-row">
+                <span className="text-sm">Grid Opacity: {options.gridOpacity}%</span>
                 <input
                   type="range"
                   className="form-range"
                   min="0"
                   max="100"
-                  value={options.hexOutlineOpacity}
-                  onChange={e => handleChange('hexOutlineOpacity', parseInt(e.target.value))}
+                  value={options.gridOpacity}
+                  onChange={e => handleChange('gridOpacity', parseInt(e.target.value))}
                   style={{ width: '120px' }}
                 />
               </div>
             )}
-
-            <div className="panel-row">
-              <span className="text-sm">Hex Fill Opacity: {options.hexFillOpacity}%</span>
-              <input
-                type="range"
-                className="form-range"
-                min="0"
-                max="100"
-                value={options.hexFillOpacity}
-                onChange={e => handleChange('hexFillOpacity', parseInt(e.target.value))}
-                style={{ width: '120px' }}
-              />
-            </div>
           </div>
 
           {/* Labels & Markers Section */}
@@ -211,32 +241,67 @@ const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
             <label className="form-label">Labels & Markers</label>
 
             <div className="panel-row mb-2">
-              <span className="text-sm">Hex Coordinates</span>
+              <span className="text-sm">Show Terrain Colors</span>
               <button
-                className={`btn btn-sm ${options.includeCoordinates ? 'btn-primary' : 'btn-secondary'}`}
-                onClick={() => handleChange('includeCoordinates', !options.includeCoordinates)}
+                className={`btn btn-sm ${options.showTerrainColors ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => handleChange('showTerrainColors', !options.showTerrainColors)}
               >
-                {options.includeCoordinates ? 'Show' : 'Hide'}
+                {options.showTerrainColors ? 'On' : 'Off'}
+              </button>
+            </div>
+
+            {options.showTerrainColors && (
+              <div className="panel-row mb-2">
+                <span className="text-sm">Hex Fill Opacity: {options.hexFillOpacity}%</span>
+                <input
+                  type="range"
+                  className="form-range"
+                  min="0"
+                  max="100"
+                  value={options.hexFillOpacity}
+                  onChange={e => handleChange('hexFillOpacity', parseInt(e.target.value))}
+                  style={{ width: '120px' }}
+                />
+              </div>
+            )}
+
+            <div className="panel-row mb-2">
+              <span className="text-sm">Show Coordinates</span>
+              <button
+                className={`btn btn-sm ${options.showCoordinates ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => handleChange('showCoordinates', !options.showCoordinates)}
+              >
+                {options.showCoordinates ? 'On' : 'Off'}
               </button>
             </div>
 
             <div className="panel-row mb-2">
-              <span className="text-sm">Terrain Symbols</span>
+              <span className="text-sm">Feature Markers</span>
               <button
-                className={`btn btn-sm ${options.includeTerrainSymbols ? 'btn-primary' : 'btn-secondary'}`}
-                onClick={() => handleChange('includeTerrainSymbols', !options.includeTerrainSymbols)}
+                className={`btn btn-sm ${options.showFeatureMarkers ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => handleChange('showFeatureMarkers', !options.showFeatureMarkers)}
               >
-                {options.includeTerrainSymbols ? 'Show' : 'Hide'}
+                {options.showFeatureMarkers ? 'On' : 'Off'}
+              </button>
+            </div>
+
+            <div className="panel-row mb-2">
+              <span className="text-sm">Faction Territories</span>
+              <button
+                className={`btn btn-sm ${options.showFactionTerritories ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => handleChange('showFactionTerritories', !options.showFactionTerritories)}
+              >
+                {options.showFactionTerritories ? 'On' : 'Off'}
               </button>
             </div>
 
             <div className="panel-row">
-              <span className="text-sm">Feature Markers</span>
+              <span className="text-sm">Fog of War</span>
               <button
-                className={`btn btn-sm ${options.includeFeatureMarkers ? 'btn-primary' : 'btn-secondary'}`}
-                onClick={() => handleChange('includeFeatureMarkers', !options.includeFeatureMarkers)}
+                className={`btn btn-sm ${options.showFogOfWar ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => handleChange('showFogOfWar', !options.showFogOfWar)}
               >
-                {options.includeFeatureMarkers ? 'Show' : 'Hide'}
+                {options.showFogOfWar ? 'On' : 'Off'}
               </button>
             </div>
           </div>
@@ -266,7 +331,7 @@ const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
             Cancel
           </button>
           <button className="btn btn-primary" onClick={handleExport}>
-            Export PNG
+            Export {options.format.toUpperCase()}
           </button>
         </div>
       </div>

--- a/src/components/HexMap.tsx
+++ b/src/components/HexMap.tsx
@@ -88,10 +88,12 @@ interface HexCellProps {
   showTerrainColors: boolean;
   showDataIndicator: boolean;
   showCoordinates: boolean;
+  showGrid: boolean;
   factionColor?: string;
   isExplored: boolean;
   showExploredStatus: boolean;
   fillOpacity: number;
+  gridOpacity: number;
   onClick: (event: React.MouseEvent) => void;
   onMouseEnter: () => void;
   onMouseLeave: () => void;
@@ -107,10 +109,12 @@ const HexCell: React.FC<HexCellProps> = React.memo(({
   showTerrainColors,
   showDataIndicator,
   showCoordinates,
+  showGrid,
   factionColor,
   isExplored,
   showExploredStatus,
   fillOpacity,
+  gridOpacity,
   onClick,
   onMouseEnter,
   onMouseLeave,
@@ -172,10 +176,15 @@ const HexCell: React.FC<HexCellProps> = React.memo(({
         fillOpacity={opacity}
         data-terrain-color={terrain.color}
         data-terrain-symbol={terrain.symbol || ''}
+        data-grid-opacity={gridOpacity}
         style={factionColor && !isSelected && !isMultiSelected ? {
           stroke: factionColor,
           strokeWidth: 3,
-        } : undefined}
+        } : showGrid ? {
+          strokeOpacity: gridOpacity,
+        } : {
+          stroke: 'none',
+        }}
       />
       
       {/* Terrain symbol */}
@@ -553,10 +562,12 @@ const HexMap = forwardRef<HexMapHandle, HexMapProps>(({
                 showTerrainColors={settings?.showTerrainColors ?? true}
                 showDataIndicator={settings?.showDataIndicators ?? true}
                 showCoordinates={settings?.showCoordinates ?? true}
+                showGrid={settings?.showGrid ?? true}
                 factionColor={factionColor}
                 isExplored={isExplored}
                 showExploredStatus={settings?.showExploredStatus ?? false}
                 fillOpacity={settings?.hexFillOpacity ?? 0.5}
+                gridOpacity={settings?.gridOpacity ?? 0.3}
                 onClick={(e) => handleHexClick(hex, e)}
                 onMouseEnter={() => handleMouseEnter(hex)}
                 onMouseLeave={handleMouseLeave}

--- a/src/components/HexMap.tsx
+++ b/src/components/HexMap.tsx
@@ -157,6 +157,9 @@ const HexCell: React.FC<HexCellProps> = React.memo(({
     <g
       className={classNames}
       transform={`translate(${x}, ${y})`}
+      data-coord={displayCoord}
+      data-coord-x={coordOffset.x}
+      data-coord-y={coordOffset.y}
       onClick={onClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
@@ -167,6 +170,8 @@ const HexCell: React.FC<HexCellProps> = React.memo(({
         points={getHexPoints(0, 0, gridConfig)}
         fill={fillColor}
         fillOpacity={opacity}
+        data-terrain-color={terrain.color}
+        data-terrain-symbol={terrain.symbol || ''}
         style={factionColor && !isSelected && !isMultiSelected ? {
           stroke: factionColor,
           strokeWidth: 3,

--- a/src/components/HexMap.tsx
+++ b/src/components/HexMap.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useState, useRef } from 'react';
+import React, { useMemo, useCallback, useState, useRef, forwardRef, useImperativeHandle } from 'react';
 import type { Hex, HexCoord, GridConfig, TerrainType, Faction, ImageOverlay, CampaignSettings } from '@/lib/types';
 import { coordToKey, hexHasUserData, getEffectiveTerrain, DEFAULT_TERRAIN_TYPES } from '@/lib/types';
 import { 
@@ -25,6 +25,12 @@ interface HexMapProps {
   onHexHover?: (coord: HexCoord | null) => void;
   onBoxSelect?: (coords: HexCoord[]) => void;
   onZoomChange?: (zoom: number) => void;
+}
+
+// Handle for accessing HexMap internals (used for image export)
+export interface HexMapHandle {
+  getSvgElement: () => SVGSVGElement | null;
+  getBackgroundImage: () => string | undefined;
 }
 
 // Generate a consistent color for a faction
@@ -252,7 +258,7 @@ const SelectionBox: React.FC<SelectionBoxProps> = ({ startX, startY, currentX, c
   );
 };
 
-const HexMap: React.FC<HexMapProps> = ({
+const HexMap = forwardRef<HexMapHandle, HexMapProps>(({
   hexes,
   gridConfig,
   settings,
@@ -266,7 +272,7 @@ const HexMap: React.FC<HexMapProps> = ({
   onHexHover,
   onBoxSelect,
   onZoomChange,
-}) => {
+}, ref) => {
   // Box selection state
   const [isDragging, setIsDragging] = useState(false);
   const [dragStart, setDragStart] = useState<{ x: number; y: number } | null>(null);
@@ -274,6 +280,12 @@ const HexMap: React.FC<HexMapProps> = ({
   const svgRef = useRef<SVGSVGElement>(null);
   const viewportRef = useRef<HTMLDivElement>(null);
   const didDragRef = useRef(false); // Track if we just completed a drag
+
+  // Expose methods for image export
+  useImperativeHandle(ref, () => ({
+    getSvgElement: () => svgRef.current,
+    getBackgroundImage: () => imageOverlay?.src,
+  }));
   
   // Native wheel event listener for zoom (needs passive: false to preventDefault)
   React.useEffect(() => {
@@ -560,6 +572,8 @@ const HexMap: React.FC<HexMapProps> = ({
       </svg>
     </div>
   );
-};
+});
+
+HexMap.displayName = 'HexMap';
 
 export default HexMap;

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,13 +1,15 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import type { CampaignSettings, GridConfig, TerrainType } from '@/lib/types';
+import type { CampaignSettings, GridConfig, TerrainType, ImageOverlay } from '@/lib/types';
 import { DEFAULT_TERRAIN_TYPES } from '@/lib/types';
 import { getHexSpacing, getHexDimensions } from '@/lib/hexUtils';
 
 interface SettingsPanelProps {
   settings: CampaignSettings;
   gridConfig: GridConfig;
+  imageOverlay?: ImageOverlay;
   onSettingsChange: (updates: Partial<CampaignSettings>) => void;
   onGridConfigChange: (updates: Partial<GridConfig>) => void;
+  onImageOverlayChange?: (updates: Partial<ImageOverlay>) => void;
   onClose: () => void;
 }
 
@@ -337,8 +339,10 @@ const TerrainTypesSection: React.FC<TerrainTypesSectionProps> = ({
 const SettingsPanel: React.FC<SettingsPanelProps> = ({
   settings,
   gridConfig,
+  imageOverlay,
   onSettingsChange,
   onGridConfigChange,
+  onImageOverlayChange,
   onClose,
 }) => {
   // Get current spacing (either custom or calculated)
@@ -507,6 +511,67 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
       
       {/* Display Settings Accordion */}
       <Accordion title="Display" defaultOpen={false}>
+        {/* Background (only for overlay maps) */}
+        {imageOverlay && onImageOverlayChange && (
+          <>
+            <div className="panel-row mb-2">
+              <span className="panel-row-label">Show Background</span>
+              <button
+                className={`btn btn-sm ${imageOverlay.visible ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => onImageOverlayChange({ visible: !imageOverlay.visible })}
+              >
+                {imageOverlay.visible ? 'On' : 'Off'}
+              </button>
+            </div>
+
+            {imageOverlay.visible && (
+              <div className="form-group">
+                <label className="form-label">
+                  Background Opacity: {Math.round((imageOverlay.opacity ?? 1) * 100)}%
+                </label>
+                <input
+                  type="range"
+                  className="form-range"
+                  min="0"
+                  max="1"
+                  step="0.05"
+                  value={imageOverlay.opacity ?? 1}
+                  onChange={e => onImageOverlayChange({ opacity: parseFloat(e.target.value) })}
+                />
+              </div>
+            )}
+          </>
+        )}
+
+        {/* Grid */}
+        <div className="panel-row mb-2">
+          <span className="panel-row-label">Show Grid</span>
+          <button
+            className={`btn btn-sm ${settings?.showGrid ? 'btn-primary' : 'btn-secondary'}`}
+            onClick={() => onSettingsChange({ showGrid: !settings?.showGrid })}
+          >
+            {settings?.showGrid ? 'On' : 'Off'}
+          </button>
+        </div>
+
+        {settings?.showGrid && (
+          <div className="form-group">
+            <label className="form-label">
+              Grid Opacity: {Math.round((settings?.gridOpacity ?? 0.3) * 100)}%
+            </label>
+            <input
+              type="range"
+              className="form-range"
+              min="0"
+              max="1"
+              step="0.05"
+              value={settings?.gridOpacity ?? 0.3}
+              onChange={e => onSettingsChange({ gridOpacity: parseFloat(e.target.value) })}
+            />
+          </div>
+        )}
+
+        {/* Terrain & Labels */}
         <div className="panel-row mb-2">
           <span className="panel-row-label">Show Terrain Colors</span>
           <button
@@ -516,22 +581,24 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
             {settings?.showTerrainColors ? 'On' : 'Off'}
           </button>
         </div>
-        
-        <div className="form-group">
-          <label className="form-label">
-            Hex Fill Opacity: {Math.round((settings?.hexFillOpacity ?? 0.5) * 100)}%
-          </label>
-          <input
-            type="range"
-            className="form-range"
-            min="0"
-            max="1"
-            step="0.05"
-            value={settings?.hexFillOpacity ?? 0.5}
-            onChange={e => onSettingsChange({ hexFillOpacity: parseFloat(e.target.value) })}
-          />
-        </div>
-        
+
+        {settings?.showTerrainColors && (
+          <div className="form-group">
+            <label className="form-label">
+              Hex Fill Opacity: {Math.round((settings?.hexFillOpacity ?? 0.5) * 100)}%
+            </label>
+            <input
+              type="range"
+              className="form-range"
+              min="0"
+              max="1"
+              step="0.05"
+              value={settings?.hexFillOpacity ?? 0.5}
+              onChange={e => onSettingsChange({ hexFillOpacity: parseFloat(e.target.value) })}
+            />
+          </div>
+        )}
+
         <div className="panel-row mb-2">
           <span className="panel-row-label">Show Coordinates</span>
           <button
@@ -541,9 +608,9 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
             {settings?.showCoordinates ? 'On' : 'Off'}
           </button>
         </div>
-        
+
         <div className="panel-row mb-2">
-          <span className="panel-row-label">Show Data Indicators</span>
+          <span className="panel-row-label">Feature Markers</span>
           <button
             className={`btn btn-sm ${settings?.showDataIndicators ? 'btn-primary' : 'btn-secondary'}`}
             onClick={() => onSettingsChange({ showDataIndicators: !settings?.showDataIndicators })}
@@ -551,7 +618,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
             {settings?.showDataIndicators ? 'On' : 'Off'}
           </button>
         </div>
-        
+
         <div className="panel-row mb-2">
           <span className="panel-row-label">Faction Territories</span>
           <button
@@ -561,7 +628,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
             {settings?.showFactionTerritories ? 'On' : 'Off'}
           </button>
         </div>
-        
+
         <div className="panel-row mb-2">
           <span className="panel-row-label">Fog of War</span>
           <button

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -118,28 +118,29 @@ const Toolbar: React.FC<ToolbarProps> = ({
                   Open / Manage...
                 </button>
                 <div className="toolbar-dropdown-divider" />
-                {map && (
-                  <>
-                    <button
-                      className="toolbar-dropdown-item"
-                      onClick={() => { onExportMap(); setShowMapsMenu(false); }}
-                    >
-                      Export (JSON)
-                    </button>
-                    <button
-                      className="toolbar-dropdown-item"
-                      onClick={() => { onExportMapAsImage(); setShowMapsMenu(false); }}
-                    >
-                      Export as Image
-                    </button>
-                  </>
-                )}
                 <button
                   className="toolbar-dropdown-item"
                   onClick={() => { onImportMap(); setShowMapsMenu(false); }}
                 >
-                  Import
+                  Import (JSON)
                 </button>
+                {map && (
+                  <button
+                    className="toolbar-dropdown-item"
+                    onClick={() => { onExportMap(); setShowMapsMenu(false); }}
+                  >
+                    Export (JSON)
+                  </button>
+                )}
+                <div className="toolbar-dropdown-divider" />
+                {map && (
+                  <button
+                    className="toolbar-dropdown-item"
+                    onClick={() => { onExportMapAsImage(); setShowMapsMenu(false); }}
+                  >
+                    Export as Image
+                  </button>
+                )}
               </div>
             )}
           </div>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -8,6 +8,7 @@ interface ToolbarProps {
   onNewMap: () => void;
   onOpenMap: () => void;
   onExportMap: () => void;
+  onExportMapAsImage: () => void;
   onImportMap: () => void;
   onOpenSettings: () => void;
   onMapNameChange: (name: string) => void;
@@ -25,6 +26,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
   onNewMap,
   onOpenMap,
   onExportMap,
+  onExportMapAsImage,
   onImportMap,
   onOpenSettings,
   onMapNameChange,
@@ -117,14 +119,22 @@ const Toolbar: React.FC<ToolbarProps> = ({
                 </button>
                 <div className="toolbar-dropdown-divider" />
                 {map && (
-                  <button 
-                    className="toolbar-dropdown-item"
-                    onClick={() => { onExportMap(); setShowMapsMenu(false); }}
-                  >
-                    Export
-                  </button>
+                  <>
+                    <button
+                      className="toolbar-dropdown-item"
+                      onClick={() => { onExportMap(); setShowMapsMenu(false); }}
+                    >
+                      Export (JSON)
+                    </button>
+                    <button
+                      className="toolbar-dropdown-item"
+                      onClick={() => { onExportMapAsImage(); setShowMapsMenu(false); }}
+                    >
+                      Export as Image
+                    </button>
+                  </>
                 )}
-                <button 
+                <button
                   className="toolbar-dropdown-item"
                   onClick={() => { onImportMap(); setShowMapsMenu(false); }}
                 >

--- a/src/lib/imageExport.ts
+++ b/src/lib/imageExport.ts
@@ -263,6 +263,13 @@ export async function exportMapAsImage(
     throw new Error('Failed to get canvas context');
   }
 
+  // Fill with dark background color if no background image
+  // This matches the app's dark theme for maps without image overlays
+  if (!backgroundImage || !opts.includeBackground) {
+    ctx.fillStyle = '#1a1a2e';
+    ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+  }
+
   // Scale the context to match resolution
   ctx.scale(scale, scale);
 

--- a/src/lib/imageExport.ts
+++ b/src/lib/imageExport.ts
@@ -1,0 +1,151 @@
+/**
+ * Image export functionality for Campaign Mapper
+ * Exports the hex map as a PNG image for use in VTT applications
+ */
+
+interface ExportOptions {
+  backgroundImage?: string;  // data URL of background image
+  filename?: string;
+}
+
+/**
+ * Inline CSS styles into SVG elements for export
+ * (External CSS won't be available when SVG is serialized)
+ */
+function inlineStyles(svg: SVGSVGElement): SVGSVGElement {
+  const clone = svg.cloneNode(true) as SVGSVGElement;
+
+  // Remove selection highlighting classes (shouldn't appear in export)
+  clone.querySelectorAll('.selected, .multi-selected').forEach(el => {
+    el.classList.remove('selected', 'multi-selected');
+  });
+
+  // Inline styles for hex polygons
+  clone.querySelectorAll('.hex-polygon').forEach(el => {
+    const polygon = el as SVGPolygonElement;
+
+    // Only set stroke if not already inline-styled (faction borders)
+    if (!polygon.style.stroke) {
+      polygon.style.stroke = 'rgba(255, 255, 255, 0.3)';
+      polygon.style.strokeWidth = '1';
+    }
+  });
+
+  // Inline styles for terrain symbols
+  clone.querySelectorAll('.hex-symbol').forEach(el => {
+    const text = el as SVGTextElement;
+    text.style.fontSize = '16px';
+    text.style.textAnchor = 'middle';
+    text.style.dominantBaseline = 'central';
+    text.style.fill = 'rgba(255, 255, 255, 0.7)';
+    text.style.pointerEvents = 'none';
+  });
+
+  // Inline styles for coordinate labels
+  clone.querySelectorAll('.hex-coord').forEach(el => {
+    const text = el as SVGTextElement;
+    text.style.fontSize = '10px';
+    text.style.textAnchor = 'middle';
+    text.style.fill = 'rgba(255, 255, 255, 0.5)';
+    text.style.pointerEvents = 'none';
+  });
+
+  // Inline styles for explored dots
+  clone.querySelectorAll('.hex-explored-dot').forEach(el => {
+    const circle = el as SVGCircleElement;
+    circle.style.fill = '#4ade80';
+    circle.style.opacity = '0.8';
+  });
+
+  return clone;
+}
+
+/**
+ * Parse SVG viewBox attribute into dimensions
+ */
+function parseViewBox(viewBox: string | null): { x: number; y: number; width: number; height: number } {
+  if (!viewBox) {
+    return { x: 0, y: 0, width: 800, height: 600 };
+  }
+
+  const parts = viewBox.split(/\s+/).map(Number);
+  return {
+    x: parts[0] || 0,
+    y: parts[1] || 0,
+    width: parts[2] || 800,
+    height: parts[3] || 600,
+  };
+}
+
+/**
+ * Load an image from a data URL
+ */
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Failed to load image'));
+    img.src = src;
+  });
+}
+
+/**
+ * Export the map as a PNG image
+ */
+export async function exportMapAsImage(
+  svgElement: SVGSVGElement,
+  options: ExportOptions = {}
+): Promise<void> {
+  const { backgroundImage, filename = 'map' } = options;
+
+  // Clone and inline styles
+  const styledSvg = inlineStyles(svgElement);
+
+  // Get dimensions from viewBox
+  const viewBox = parseViewBox(svgElement.getAttribute('viewBox'));
+
+  // Create canvas
+  const canvas = document.createElement('canvas');
+  canvas.width = viewBox.width;
+  canvas.height = viewBox.height;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Failed to get canvas context');
+  }
+
+  // Draw background image if present
+  if (backgroundImage) {
+    try {
+      const bgImg = await loadImage(backgroundImage);
+      ctx.drawImage(bgImg, 0, 0, viewBox.width, viewBox.height);
+    } catch (e) {
+      console.warn('Failed to draw background image:', e);
+      // Continue without background
+    }
+  }
+
+  // Serialize SVG to data URL
+  const serializer = new XMLSerializer();
+  const svgString = serializer.serializeToString(styledSvg);
+  const svgDataUrl = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svgString);
+
+  // Draw SVG onto canvas
+  const svgImg = await loadImage(svgDataUrl);
+  ctx.drawImage(svgImg, 0, 0, viewBox.width, viewBox.height);
+
+  // Export as PNG
+  canvas.toBlob((blob) => {
+    if (!blob) {
+      throw new Error('Failed to create image blob');
+    }
+
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${filename.replace(/\s+/g, '_')}.png`;
+    a.click();
+
+    URL.revokeObjectURL(url);
+  }, 'image/png');
+}

--- a/src/lib/imageExport.ts
+++ b/src/lib/imageExport.ts
@@ -3,52 +3,166 @@
  * Exports the hex map as a PNG image for use in VTT applications
  */
 
-interface ExportOptions {
-  backgroundImage?: string;  // data URL of background image
+export type ImageFormat = 'png' | 'jpeg' | 'webp';
+
+export interface ImageExportOptions {
   filename?: string;
+  format?: ImageFormat;
+  quality?: number;
+  backgroundImage?: string;
+  includeBackground?: boolean;
+  backgroundOpacity?: number;
+  includeHexOutlines?: boolean;
+  hexOutlineOpacity?: number;
+  hexFillOpacity?: number;
+  includeCoordinates?: boolean;
+  includeFeatureMarkers?: boolean;
+  includeTerrainSymbols?: boolean;
+  scale?: number;
+}
+
+const DEFAULT_OPTIONS: Required<Omit<ImageExportOptions, 'backgroundImage'>> = {
+  filename: 'map',
+  format: 'png',
+  quality: 85,
+  includeBackground: true,
+  backgroundOpacity: 100,
+  includeHexOutlines: true,
+  hexOutlineOpacity: 30,
+  hexFillOpacity: 50,
+  includeCoordinates: true,
+  includeFeatureMarkers: true,
+  includeTerrainSymbols: true,
+  scale: 1,
+};
+
+/**
+ * Create an SVG text element
+ */
+function createSvgText(
+  content: string,
+  x: number,
+  y: number,
+  className: string,
+  styles: Record<string, string>
+): SVGTextElement {
+  const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+  text.setAttribute('class', className);
+  text.setAttribute('x', String(x));
+  text.setAttribute('y', String(y));
+  text.textContent = content;
+  Object.assign(text.style, styles);
+  return text;
 }
 
 /**
  * Inline CSS styles into SVG elements for export
- * (External CSS won't be available when SVG is serialized)
+ * Uses data attributes to ensure terrain colors/symbols are available
+ * even when display settings have them hidden
  */
-function inlineStyles(svg: SVGSVGElement): SVGSVGElement {
+function inlineStyles(svg: SVGSVGElement, options: ImageExportOptions): SVGSVGElement {
   const clone = svg.cloneNode(true) as SVGSVGElement;
+  const opts = { ...DEFAULT_OPTIONS, ...options };
 
   // Remove selection highlighting classes (shouldn't appear in export)
   clone.querySelectorAll('.selected, .multi-selected').forEach(el => {
     el.classList.remove('selected', 'multi-selected');
   });
 
-  // Inline styles for hex polygons
-  clone.querySelectorAll('.hex-polygon').forEach(el => {
-    const polygon = el as SVGPolygonElement;
+  // Process each hex group
+  clone.querySelectorAll('.hex').forEach(hexGroup => {
+    const group = hexGroup as SVGGElement;
+    const polygon = group.querySelector('.hex-polygon') as SVGPolygonElement | null;
 
-    // Only set stroke if not already inline-styled (faction borders)
-    if (!polygon.style.stroke) {
-      polygon.style.stroke = 'rgba(255, 255, 255, 0.3)';
-      polygon.style.strokeWidth = '1';
+    if (!polygon) return;
+
+    // Get terrain data from data attributes
+    const terrainColor = polygon.getAttribute('data-terrain-color') || '#808080';
+    const terrainSymbol = polygon.getAttribute('data-terrain-symbol') || '';
+
+    // Apply terrain fill color from data attribute (overrides current fill)
+    // This ensures export works even when "Show Terrain Colors" is off
+    polygon.setAttribute('fill', terrainColor);
+    polygon.setAttribute('fill-opacity', String(opts.hexFillOpacity / 100));
+
+    // Handle hex outlines
+    if (opts.includeHexOutlines) {
+      // Only set stroke if not already inline-styled (faction borders)
+      if (!polygon.style.stroke) {
+        const outlineAlpha = opts.hexOutlineOpacity / 100;
+        polygon.style.stroke = `rgba(255, 255, 255, ${outlineAlpha})`;
+        polygon.style.strokeWidth = '1';
+      }
+    } else {
+      // Remove outlines entirely (unless faction border)
+      if (!polygon.style.stroke || polygon.style.stroke.includes('255, 255, 255')) {
+        polygon.style.stroke = 'none';
+      }
+    }
+
+    // Handle terrain symbols
+    let symbolEl = group.querySelector('.hex-symbol') as SVGTextElement | null;
+    if (opts.includeTerrainSymbols && terrainSymbol) {
+      if (!symbolEl) {
+        // Create symbol element if it doesn't exist
+        symbolEl = createSvgText(terrainSymbol, 0, 0, 'hex-symbol', {
+          fontSize: '16px',
+          textAnchor: 'middle',
+          dominantBaseline: 'central',
+          fill: 'rgba(255, 255, 255, 0.7)',
+          pointerEvents: 'none',
+        });
+        group.appendChild(symbolEl);
+      } else {
+        // Style existing symbol
+        symbolEl.style.fontSize = '16px';
+        symbolEl.style.textAnchor = 'middle';
+        symbolEl.style.dominantBaseline = 'central';
+        symbolEl.style.fill = 'rgba(255, 255, 255, 0.7)';
+        symbolEl.style.pointerEvents = 'none';
+      }
+    } else if (symbolEl) {
+      symbolEl.remove();
+    }
+
+    // Handle coordinate labels
+    const coordValue = group.getAttribute('data-coord');
+    const coordX = parseFloat(group.getAttribute('data-coord-x') || '0');
+    const coordY = parseFloat(group.getAttribute('data-coord-y') || '0');
+    let coordEl = group.querySelector('.hex-coord') as SVGTextElement | null;
+
+    if (opts.includeCoordinates && coordValue) {
+      if (!coordEl) {
+        // Create coordinate element if it doesn't exist
+        coordEl = createSvgText(coordValue, coordX, coordY, 'hex-coord', {
+          fontSize: '10px',
+          textAnchor: 'middle',
+          fill: 'rgba(255, 255, 255, 0.5)',
+          pointerEvents: 'none',
+        });
+        group.appendChild(coordEl);
+      } else {
+        // Style existing coordinate
+        coordEl.style.fontSize = '10px';
+        coordEl.style.textAnchor = 'middle';
+        coordEl.style.fill = 'rgba(255, 255, 255, 0.5)';
+        coordEl.style.pointerEvents = 'none';
+      }
+    } else if (coordEl) {
+      coordEl.remove();
     }
   });
 
-  // Inline styles for terrain symbols
-  clone.querySelectorAll('.hex-symbol').forEach(el => {
-    const text = el as SVGTextElement;
-    text.style.fontSize = '16px';
-    text.style.textAnchor = 'middle';
-    text.style.dominantBaseline = 'central';
-    text.style.fill = 'rgba(255, 255, 255, 0.7)';
-    text.style.pointerEvents = 'none';
-  });
-
-  // Inline styles for coordinate labels
-  clone.querySelectorAll('.hex-coord').forEach(el => {
-    const text = el as SVGTextElement;
-    text.style.fontSize = '10px';
-    text.style.textAnchor = 'middle';
-    text.style.fill = 'rgba(255, 255, 255, 0.5)';
-    text.style.pointerEvents = 'none';
-  });
+  // Handle feature markers
+  if (opts.includeFeatureMarkers) {
+    // Style feature indicator text
+    clone.querySelectorAll('.hex-feature-indicator text').forEach(el => {
+      const text = el as SVGTextElement;
+      text.style.pointerEvents = 'none';
+    });
+  } else {
+    clone.querySelectorAll('.hex-feature-indicator').forEach(el => el.remove());
+  }
 
   // Inline styles for explored dots
   clone.querySelectorAll('.hex-explored-dot').forEach(el => {
@@ -90,35 +204,48 @@ function loadImage(src: string): Promise<HTMLImageElement> {
 }
 
 /**
- * Export the map as a PNG image
+ * Export the map as an image (PNG, JPEG, or WebP)
  */
 export async function exportMapAsImage(
   svgElement: SVGSVGElement,
-  options: ExportOptions = {}
+  options: ImageExportOptions = {}
 ): Promise<void> {
-  const { backgroundImage, filename = 'map' } = options;
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+  const { backgroundImage } = options;
 
   // Clone and inline styles
-  const styledSvg = inlineStyles(svgElement);
+  const styledSvg = inlineStyles(svgElement, opts);
 
   // Get dimensions from viewBox
   const viewBox = parseViewBox(svgElement.getAttribute('viewBox'));
 
+  // Apply scale to canvas dimensions
+  const scale = opts.scale;
+  const canvasWidth = Math.round(viewBox.width * scale);
+  const canvasHeight = Math.round(viewBox.height * scale);
+
   // Create canvas
   const canvas = document.createElement('canvas');
-  canvas.width = viewBox.width;
-  canvas.height = viewBox.height;
+  canvas.width = canvasWidth;
+  canvas.height = canvasHeight;
 
   const ctx = canvas.getContext('2d');
   if (!ctx) {
     throw new Error('Failed to get canvas context');
   }
 
-  // Draw background image if present
-  if (backgroundImage) {
+  // Scale the context to match resolution
+  ctx.scale(scale, scale);
+
+  // Draw background image if present and enabled
+  if (backgroundImage && opts.includeBackground) {
     try {
       const bgImg = await loadImage(backgroundImage);
+
+      // Apply background opacity
+      ctx.globalAlpha = opts.backgroundOpacity / 100;
       ctx.drawImage(bgImg, 0, 0, viewBox.width, viewBox.height);
+      ctx.globalAlpha = 1;
     } catch (e) {
       console.warn('Failed to draw background image:', e);
       // Continue without background
@@ -134,7 +261,24 @@ export async function exportMapAsImage(
   const svgImg = await loadImage(svgDataUrl);
   ctx.drawImage(svgImg, 0, 0, viewBox.width, viewBox.height);
 
-  // Export as PNG
+  // Determine MIME type and file extension
+  const mimeTypes: Record<ImageFormat, string> = {
+    png: 'image/png',
+    jpeg: 'image/jpeg',
+    webp: 'image/webp',
+  };
+  const extensions: Record<ImageFormat, string> = {
+    png: 'png',
+    jpeg: 'jpg',
+    webp: 'webp',
+  };
+  const mimeType = mimeTypes[opts.format];
+  const extension = extensions[opts.format];
+
+  // Quality only applies to jpeg and webp (0-1 range)
+  const quality = opts.format === 'png' ? undefined : opts.quality / 100;
+
+  // Export image
   canvas.toBlob((blob) => {
     if (!blob) {
       throw new Error('Failed to create image blob');
@@ -143,9 +287,9 @@ export async function exportMapAsImage(
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `${filename.replace(/\s+/g, '_')}.png`;
+    a.download = `${opts.filename.replace(/\s+/g, '_')}.${extension}`;
     a.click();
 
     URL.revokeObjectURL(url);
-  }, 'image/png');
+  }, mimeType, quality);
 }

--- a/src/lib/imageExport.ts
+++ b/src/lib/imageExport.ts
@@ -12,12 +12,14 @@ export interface ImageExportOptions {
   backgroundImage?: string;
   includeBackground?: boolean;
   backgroundOpacity?: number;
-  includeHexOutlines?: boolean;
-  hexOutlineOpacity?: number;
+  showGrid?: boolean;
+  gridOpacity?: number;
   hexFillOpacity?: number;
-  includeCoordinates?: boolean;
-  includeFeatureMarkers?: boolean;
-  includeTerrainSymbols?: boolean;
+  showTerrainColors?: boolean;
+  showCoordinates?: boolean;
+  showFeatureMarkers?: boolean;
+  showFactionTerritories?: boolean;
+  showFogOfWar?: boolean;
   scale?: number;
 }
 
@@ -27,12 +29,14 @@ const DEFAULT_OPTIONS: Required<Omit<ImageExportOptions, 'backgroundImage'>> = {
   quality: 85,
   includeBackground: true,
   backgroundOpacity: 100,
-  includeHexOutlines: true,
-  hexOutlineOpacity: 30,
+  showGrid: true,
+  gridOpacity: 30,
   hexFillOpacity: 50,
-  includeCoordinates: true,
-  includeFeatureMarkers: true,
-  includeTerrainSymbols: true,
+  showTerrainColors: true,
+  showCoordinates: true,
+  showFeatureMarkers: true,
+  showFactionTerritories: true,
+  showFogOfWar: false,
   scale: 1,
 };
 
@@ -82,15 +86,19 @@ function inlineStyles(svg: SVGSVGElement, options: ImageExportOptions): SVGSVGEl
 
     // Apply terrain fill color from data attribute (overrides current fill)
     // This ensures export works even when "Show Terrain Colors" is off
-    polygon.setAttribute('fill', terrainColor);
-    polygon.setAttribute('fill-opacity', String(opts.hexFillOpacity / 100));
+    if (opts.showTerrainColors) {
+      polygon.setAttribute('fill', terrainColor);
+      polygon.setAttribute('fill-opacity', String(opts.hexFillOpacity / 100));
+    } else {
+      polygon.setAttribute('fill', 'transparent');
+    }
 
-    // Handle hex outlines
-    if (opts.includeHexOutlines) {
+    // Handle hex grid outlines
+    if (opts.showGrid) {
       // Only set stroke if not already inline-styled (faction borders)
       if (!polygon.style.stroke) {
-        const outlineAlpha = opts.hexOutlineOpacity / 100;
-        polygon.style.stroke = `rgba(255, 255, 255, ${outlineAlpha})`;
+        const gridAlpha = opts.gridOpacity / 100;
+        polygon.style.stroke = `rgba(255, 255, 255, ${gridAlpha})`;
         polygon.style.strokeWidth = '1';
       }
     } else {
@@ -100,9 +108,9 @@ function inlineStyles(svg: SVGSVGElement, options: ImageExportOptions): SVGSVGEl
       }
     }
 
-    // Handle terrain symbols
+    // Handle terrain symbols (tied to terrain colors setting)
     let symbolEl = group.querySelector('.hex-symbol') as SVGTextElement | null;
-    if (opts.includeTerrainSymbols && terrainSymbol) {
+    if (opts.showTerrainColors && terrainSymbol) {
       if (!symbolEl) {
         // Create symbol element if it doesn't exist
         symbolEl = createSvgText(terrainSymbol, 0, 0, 'hex-symbol', {
@@ -131,7 +139,7 @@ function inlineStyles(svg: SVGSVGElement, options: ImageExportOptions): SVGSVGEl
     const coordY = parseFloat(group.getAttribute('data-coord-y') || '0');
     let coordEl = group.querySelector('.hex-coord') as SVGTextElement | null;
 
-    if (opts.includeCoordinates && coordValue) {
+    if (opts.showCoordinates && coordValue) {
       if (!coordEl) {
         // Create coordinate element if it doesn't exist
         coordEl = createSvgText(coordValue, coordX, coordY, 'hex-coord', {
@@ -154,7 +162,7 @@ function inlineStyles(svg: SVGSVGElement, options: ImageExportOptions): SVGSVGEl
   });
 
   // Handle feature markers
-  if (opts.includeFeatureMarkers) {
+  if (opts.showFeatureMarkers) {
     // Style feature indicator text
     clone.querySelectorAll('.hex-feature-indicator text').forEach(el => {
       const text = el as SVGTextElement;
@@ -162,6 +170,27 @@ function inlineStyles(svg: SVGSVGElement, options: ImageExportOptions): SVGSVGEl
     });
   } else {
     clone.querySelectorAll('.hex-feature-indicator').forEach(el => el.remove());
+  }
+
+  // Handle faction territories
+  if (!opts.showFactionTerritories) {
+    // Remove faction border styling
+    clone.querySelectorAll('.hex-polygon').forEach(el => {
+      const polygon = el as SVGPolygonElement;
+      // Check if this has faction border (colored stroke that's not the default white grid)
+      if (polygon.style.stroke && !polygon.style.stroke.includes('255, 255, 255')) {
+        polygon.style.stroke = opts.showGrid ? `rgba(255, 255, 255, ${opts.gridOpacity / 100})` : 'none';
+        polygon.style.strokeWidth = opts.showGrid ? '1' : '0';
+      }
+    });
+  }
+
+  // Handle fog of war (explored status)
+  if (!opts.showFogOfWar) {
+    clone.querySelectorAll('.hex-explored-dot').forEach(el => el.remove());
+    clone.querySelectorAll('.hex-unexplored').forEach(el => {
+      el.classList.remove('hex-unexplored');
+    });
   }
 
   // Inline styles for explored dots

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -281,10 +281,11 @@ export interface CampaignSettings {
   showGrid: boolean;
   showCoordinates: boolean;
   hexFillOpacity: number;
-  
+  gridOpacity: number;
+
   // Available tags for quick selection
   availableTags: string[];
-  
+
   // Custom terrain types (in addition to defaults)
   customTerrainTypes: TerrainType[];
 }
@@ -297,6 +298,7 @@ export const DEFAULT_CAMPAIGN_SETTINGS: CampaignSettings = {
   showGrid: true,
   showCoordinates: true,
   hexFillOpacity: 0.5,
+  gridOpacity: 0.3,
   availableTags: [], // User-defined tags only
   customTerrainTypes: [],
 };


### PR DESCRIPTION
## Summary

Adds the ability to export hex maps as images (PNG, JPEG, or WebP) for use in Virtual Tabletop applications. Includes a configuration modal for customizing the exported image, with settings unified between the map display and export dialog.

## Features

- **Export as Image**: New option in Maps dropdown to export the current map as an image file
- **Format selection**: Choose between PNG (lossless), JPEG (smaller files), or WebP (modern, smallest)
- **Quality slider**: Adjust compression quality for JPEG/WebP formats (10-100%)
- **Resolution scaling**: Export at 0.25x, 0.5x, 1x, 2x, or 3x resolution
- **Configurable layers** (unified terminology between map settings and export):
  - Show Background (with opacity control)
  - Show Grid (with opacity control)
  - Show Terrain Colors (with hex fill opacity control)
  - Show Coordinates
  - Feature Markers
  - Faction Territories
  - Fog of War
- **Use Map Display Settings**: One-click button to copy all current map display settings to export options
- **New map settings**: Added Show Grid and Show Background toggles to the Settings panel

## Technical Changes

- New `ExportImageDialog` component for export configuration
- New `imageExport.ts` module with canvas compositing logic
- Added `forwardRef` to `HexMap` component to expose SVG element for export
- Store terrain data as HTML data attributes on hex elements to support export when "Show Terrain Colors" is off
- Reorganized Maps dropdown menu for consistency (grouped JSON import/export)
- Unified settings terminology between `SettingsPanel` and `ExportImageDialog`
- Added `showGrid` prop to `HexCell` component for proper grid toggling
- Opacity sliders are hidden when their parent toggle is off

## Test Plan

- [ ] Create a map with terrain, features, and coordinates
- [ ] Export with default settings - verify PNG downloads correctly
- [ ] Toggle each option off and verify it's excluded from export
- [ ] Test JPEG and WebP formats - verify smaller file sizes
- [ ] Test resolution scaling - verify image dimensions change
- [ ] Test with "Show Terrain Colors" off - verify export still shows terrain
- [ ] Test with background image overlay - verify background appears in export
- [ ] Toggle "Show Grid" in map settings - verify grid lines appear/disappear
- [ ] Toggle "Show Background" in map settings - verify background appears/disappears
- [ ] Click "Use Map Display Settings" in export dialog - verify all settings are copied
- [ ] Verify opacity sliders hide when their toggle is off (in both settings and export)
