### PR TITLE
Add hyperlinks to hex campaign data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "campaign-mapper",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Hex Map Campaign Manager for TTRPGs - overlay images, generate terrain, track campaigns",
   "type": "module",
   "scripts": {

--- a/src/components/ExportImageDialog.tsx
+++ b/src/components/ExportImageDialog.tsx
@@ -15,6 +15,7 @@ export interface ImageExportOptions {
   showTerrainColors: boolean;
   showCoordinates: boolean;
   showFeatureMarkers: boolean;
+  showLinkIndicators: boolean;
   showFactionTerritories: boolean;
   showFogOfWar: boolean;
   scale: number;
@@ -43,6 +44,7 @@ const DEFAULT_OPTIONS: ImageExportOptions = {
   showTerrainColors: true,
   showCoordinates: true,
   showFeatureMarkers: true,
+  showLinkIndicators: true,
   showFactionTerritories: true,
   showFogOfWar: false,
   scale: 1,
@@ -89,6 +91,7 @@ const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
       showTerrainColors: mapSettings.showTerrainColors,
       showCoordinates: mapSettings.showCoordinates,
       showFeatureMarkers: mapSettings.showDataIndicators,
+      showLinkIndicators: mapSettings.showLinkIndicators ?? true,
       showFactionTerritories: mapSettings.showFactionTerritories,
       showFogOfWar: mapSettings.showExploredStatus,
     }));
@@ -282,6 +285,16 @@ const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
                 onClick={() => handleChange('showFeatureMarkers', !options.showFeatureMarkers)}
               >
                 {options.showFeatureMarkers ? 'On' : 'Off'}
+              </button>
+            </div>
+
+            <div className="panel-row mb-2">
+              <span className="text-sm">Link Indicators</span>
+              <button
+                className={`btn btn-sm ${options.showLinkIndicators ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => handleChange('showLinkIndicators', !options.showLinkIndicators)}
+              >
+                {options.showLinkIndicators ? 'On' : 'Off'}
               </button>
             </div>
 

--- a/src/components/HexDetailPanel.tsx
+++ b/src/components/HexDetailPanel.tsx
@@ -125,6 +125,15 @@ const HexDetailPanel: React.FC<HexDetailPanelProps> = ({
   const [isAddingFeatureNote, setIsAddingFeatureNote] = useState(false);
   const [isEditingFeatureNotes, setIsEditingFeatureNotes] = useState(false);
 
+  // Links state
+  const [newLinkLabel, setNewLinkLabel] = useState('');
+  const [newLinkUrl, setNewLinkUrl] = useState('');
+  const [isAddingLink, setIsAddingLink] = useState(false);
+  const [isEditingLinks, setIsEditingLinks] = useState(false);
+  const [editingLinkLabel, setEditingLinkLabel] = useState<string | null>(null);
+  const [editLinkLabel, setEditLinkLabel] = useState('');
+  const [editLinkUrl, setEditLinkUrl] = useState('');
+
   // Overview edit mode state
   const [isEditingOverview, setIsEditingOverview] = useState(false);
   const [isEditingTags, setIsEditingTags] = useState(false);
@@ -485,6 +494,58 @@ const HexDetailPanel: React.FC<HexDetailPanelProps> = ({
 
     return sorted;
   }, [hex.featureType, campaignData.featureNotes]);
+
+  // Links handlers
+  const handleAddLink = useCallback(() => {
+    if (!newLinkLabel.trim() || !newLinkUrl.trim()) return;
+    const links = campaignData.links || {};
+    // Don't overwrite existing links with same label
+    if (!(newLinkLabel.trim() in links)) {
+      onUpdate({ links: { ...links, [newLinkLabel.trim()]: newLinkUrl.trim() } });
+    }
+    setNewLinkLabel('');
+    setNewLinkUrl('');
+    setIsAddingLink(false);
+  }, [newLinkLabel, newLinkUrl, campaignData.links, onUpdate]);
+
+  const handleDeleteLink = useCallback((label: string) => {
+    const links = { ...campaignData.links };
+    delete links[label];
+    onUpdate({ links: Object.keys(links).length > 0 ? links : undefined });
+  }, [campaignData.links, onUpdate]);
+
+  const handleStartEditLink = useCallback((label: string) => {
+    const url = campaignData.links?.[label] || '';
+    setEditingLinkLabel(label);
+    setEditLinkLabel(label);
+    setEditLinkUrl(url);
+  }, [campaignData.links]);
+
+  const handleSaveEditLink = useCallback(() => {
+    if (!editingLinkLabel || !editLinkLabel.trim() || !editLinkUrl.trim()) return;
+    const links = { ...campaignData.links };
+    // Remove old label if it changed
+    if (editingLinkLabel !== editLinkLabel.trim()) {
+      delete links[editingLinkLabel];
+    }
+    // Add with new/same label
+    links[editLinkLabel.trim()] = editLinkUrl.trim();
+    onUpdate({ links });
+    setEditingLinkLabel(null);
+    setEditLinkLabel('');
+    setEditLinkUrl('');
+  }, [editingLinkLabel, editLinkLabel, editLinkUrl, campaignData.links, onUpdate]);
+
+  const handleCancelEditLink = useCallback(() => {
+    setEditingLinkLabel(null);
+    setEditLinkLabel('');
+    setEditLinkUrl('');
+  }, []);
+
+  // Get link entries as array for display
+  const linkEntries = React.useMemo(() => {
+    return Object.entries(campaignData.links || {}).sort((a, b) => a[0].localeCompare(b[0]));
+  }, [campaignData.links]);
 
   // Faction territory handlers
   const handleAddToFaction = useCallback((factionId: string) => {
@@ -1369,6 +1430,7 @@ const HexDetailPanel: React.FC<HexDetailPanelProps> = ({
       
       {/* Campaign Tab */}
       {activeTab === 'campaign' && (
+        <>
         <div className="panel">
           <div className="panel-header">
             <span className="panel-title">Campaign Notes</span>
@@ -1489,6 +1551,178 @@ const HexDetailPanel: React.FC<HexDetailPanelProps> = ({
             )}
           </div>
         </div>
+
+        {/* Links Section */}
+        <div className="panel">
+          <div className="panel-header">
+            <span className="panel-title">Links</span>
+            <button
+              className="btn btn-ghost btn-sm"
+              onClick={() => setIsEditingLinks(!isEditingLinks)}
+              style={{ padding: '2px 8px', fontSize: '0.75rem' }}
+            >
+              {isEditingLinks ? 'Done' : 'Edit'}
+            </button>
+          </div>
+          <div className="panel-content">
+            {isEditingLinks ? (
+              <>
+                {/* Edit mode - show links with edit/delete buttons */}
+                {linkEntries.map(([label, url]) => (
+                  editingLinkLabel === label ? (
+                    <div key={label} className="form-group mb-3" style={{ padding: '8px', backgroundColor: 'var(--bg-secondary)', borderRadius: '4px' }}>
+                      <label className="form-label">Label</label>
+                      <input
+                        type="text"
+                        className="form-input mb-2"
+                        value={editLinkLabel}
+                        onChange={(e) => setEditLinkLabel(e.target.value)}
+                        autoFocus
+                      />
+                      <label className="form-label">URL</label>
+                      <input
+                        type="url"
+                        className="form-input mb-2"
+                        value={editLinkUrl}
+                        onChange={(e) => setEditLinkUrl(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') handleSaveEditLink();
+                          if (e.key === 'Escape') handleCancelEditLink();
+                        }}
+                      />
+                      <div className="flex gap-2">
+                        <button
+                          className="btn btn-primary btn-sm"
+                          onClick={handleSaveEditLink}
+                          disabled={!editLinkLabel.trim() || !editLinkUrl.trim()}
+                        >
+                          Save
+                        </button>
+                        <button
+                          className="btn btn-secondary btn-sm"
+                          onClick={handleCancelEditLink}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div key={label} className="panel-row mb-2" style={{ alignItems: 'center' }}>
+                      <span className="panel-row-label" style={{ flex: 1 }}>{label}</span>
+                      <span className="text-muted text-sm" style={{ flex: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {url}
+                      </span>
+                      <button
+                        className="btn btn-ghost btn-sm"
+                        onClick={() => handleStartEditLink(label)}
+                        title={`Edit "${label}" link`}
+                        style={{ padding: '2px 6px', fontSize: '0.75rem', marginLeft: '8px' }}
+                      >
+                        ✎
+                      </button>
+                      <button
+                        className="btn btn-ghost btn-sm"
+                        onClick={() => handleDeleteLink(label)}
+                        title={`Delete "${label}" link`}
+                        style={{ padding: '2px 6px', fontSize: '0.75rem' }}
+                      >
+                        ×
+                      </button>
+                    </div>
+                  )
+                ))}
+
+                {/* Empty state */}
+                {linkEntries.length === 0 && !isAddingLink && !editingLinkLabel && (
+                  <p className="text-muted text-sm mb-3">No links yet. Add one below.</p>
+                )}
+
+                {/* Add new link */}
+                {isAddingLink ? (
+                  <div className="form-group">
+                    <label className="form-label">Label</label>
+                    <input
+                      type="text"
+                      className="form-input mb-2"
+                      value={newLinkLabel}
+                      onChange={(e) => setNewLinkLabel(e.target.value)}
+                      placeholder="e.g., World Anvil, Session Notes..."
+                      autoFocus
+                    />
+                    <label className="form-label">URL</label>
+                    <input
+                      type="url"
+                      className="form-input mb-2"
+                      value={newLinkUrl}
+                      onChange={(e) => setNewLinkUrl(e.target.value)}
+                      placeholder="https://..."
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') handleAddLink();
+                        if (e.key === 'Escape') {
+                          setIsAddingLink(false);
+                          setNewLinkLabel('');
+                          setNewLinkUrl('');
+                        }
+                      }}
+                    />
+                    <div className="flex gap-2">
+                      <button
+                        className="btn btn-primary btn-sm"
+                        onClick={handleAddLink}
+                        disabled={!newLinkLabel.trim() || !newLinkUrl.trim()}
+                      >
+                        Add
+                      </button>
+                      <button
+                        className="btn btn-secondary btn-sm"
+                        onClick={() => {
+                          setIsAddingLink(false);
+                          setNewLinkLabel('');
+                          setNewLinkUrl('');
+                        }}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    className="btn btn-secondary"
+                    onClick={() => setIsAddingLink(true)}
+                    style={{ width: '100%' }}
+                  >
+                    + Add Link
+                  </button>
+                )}
+              </>
+            ) : (
+              <>
+                {/* View mode - show clickable links */}
+                {linkEntries.length > 0 ? (
+                  linkEntries.map(([label, url]) => (
+                    <div key={label} className="mb-2">
+                      <a
+                        href={url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{
+                          color: 'var(--accent-primary)',
+                          textDecoration: 'none',
+                        }}
+                        title={url}
+                      >
+                        🔗 {label}
+                      </a>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-muted text-sm">No links yet. Click Edit to add some.</p>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+        </>
       )}
 
       {/* Generate Tab */}

--- a/src/components/HexMap.tsx
+++ b/src/components/HexMap.tsx
@@ -89,6 +89,8 @@ interface HexCellProps {
   showDataIndicator: boolean;
   showCoordinates: boolean;
   showGrid: boolean;
+  showLinkIndicators: boolean;
+  hasLinks: boolean;
   factionColor?: string;
   isExplored: boolean;
   showExploredStatus: boolean;
@@ -110,6 +112,8 @@ const HexCell: React.FC<HexCellProps> = React.memo(({
   showDataIndicator,
   showCoordinates,
   showGrid,
+  showLinkIndicators,
+  hasLinks,
   factionColor,
   isExplored,
   showExploredStatus,
@@ -226,7 +230,29 @@ const HexCell: React.FC<HexCellProps> = React.memo(({
           r={4}
         />
       )}
-      
+
+      {/* Link indicator */}
+      {showLinkIndicators && hasLinks && (!showExploredStatus || isExplored) && (
+        <g className="hex-link-indicator">
+          <circle
+            cx={gridConfig.orientation === 'pointy-top' ? gridConfig.hexSize * 0.55 : gridConfig.hexSize * 0.5}
+            cy={gridConfig.orientation === 'pointy-top' ? -hexHeight * 0.15 : gridConfig.hexSize * 0.5}
+            r={7}
+            fill="#4a90d9"
+          />
+          <text
+            x={gridConfig.orientation === 'pointy-top' ? gridConfig.hexSize * 0.55 : gridConfig.hexSize * 0.5}
+            y={gridConfig.orientation === 'pointy-top' ? -hexHeight * 0.15 : gridConfig.hexSize * 0.5}
+            fill="#fff"
+            fontSize="8"
+            textAnchor="middle"
+            dominantBaseline="central"
+          >
+            🔗
+          </text>
+        </g>
+      )}
+
       {/* Coordinate label */}
       {showCoordinates && (!showExploredStatus || isExplored) && (
         <text
@@ -563,6 +589,8 @@ const HexMap = forwardRef<HexMapHandle, HexMapProps>(({
                 showDataIndicator={settings?.showDataIndicators ?? true}
                 showCoordinates={settings?.showCoordinates ?? true}
                 showGrid={settings?.showGrid ?? true}
+                showLinkIndicators={settings?.showLinkIndicators ?? true}
+                hasLinks={!!(hex.campaignData?.links && Object.keys(hex.campaignData.links).length > 0)}
                 factionColor={factionColor}
                 isExplored={isExplored}
                 showExploredStatus={settings?.showExploredStatus ?? false}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -620,6 +620,16 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
         </div>
 
         <div className="panel-row mb-2">
+          <span className="panel-row-label">Link Indicators</span>
+          <button
+            className={`btn btn-sm ${settings?.showLinkIndicators ?? true ? 'btn-primary' : 'btn-secondary'}`}
+            onClick={() => onSettingsChange({ showLinkIndicators: !(settings?.showLinkIndicators ?? true) })}
+          >
+            {(settings?.showLinkIndicators ?? true) ? 'On' : 'Off'}
+          </button>
+        </div>
+
+        <div className="panel-row mb-2">
           <span className="panel-row-label">Faction Territories</span>
           <button
             className={`btn btn-sm ${settings?.showFactionTerritories ? 'btn-primary' : 'btn-secondary'}`}

--- a/src/lib/imageExport.ts
+++ b/src/lib/imageExport.ts
@@ -18,6 +18,7 @@ export interface ImageExportOptions {
   showTerrainColors?: boolean;
   showCoordinates?: boolean;
   showFeatureMarkers?: boolean;
+  showLinkIndicators?: boolean;
   showFactionTerritories?: boolean;
   showFogOfWar?: boolean;
   scale?: number;
@@ -35,6 +36,7 @@ const DEFAULT_OPTIONS: Required<Omit<ImageExportOptions, 'backgroundImage'>> = {
   showTerrainColors: true,
   showCoordinates: true,
   showFeatureMarkers: true,
+  showLinkIndicators: true,
   showFactionTerritories: true,
   showFogOfWar: false,
   scale: 1,
@@ -170,6 +172,17 @@ function inlineStyles(svg: SVGSVGElement, options: ImageExportOptions): SVGSVGEl
     });
   } else {
     clone.querySelectorAll('.hex-feature-indicator').forEach(el => el.remove());
+  }
+
+  // Handle link indicators
+  if (opts.showLinkIndicators) {
+    // Style link indicator text
+    clone.querySelectorAll('.hex-link-indicator text').forEach(el => {
+      const text = el as SVGTextElement;
+      text.style.pointerEvents = 'none';
+    });
+  } else {
+    clone.querySelectorAll('.hex-link-indicator').forEach(el => el.remove());
   }
 
   // Handle faction territories

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -105,6 +105,9 @@ export interface HexCampaignData {
   // Custom user-defined fields (for programmatic use)
   customFields?: Record<string, string | number | boolean>;
 
+  // External links - key is label, value is URL
+  links?: Record<string, string>;
+
   // State tracking
   explored?: boolean;
   hidden?: boolean;
@@ -146,6 +149,7 @@ export function hexHasUserData(hex: Hex): boolean {
     data.terrainOverride ||
     data.featureOverride ||
     (data.customFields && Object.keys(data.customFields).length > 0) ||
+    (data.links && Object.keys(data.links).length > 0) ||
     data.explored ||
     data.hidden
   );
@@ -280,6 +284,7 @@ export interface CampaignSettings {
   showTerrainColors: boolean;
   showGrid: boolean;
   showCoordinates: boolean;
+  showLinkIndicators: boolean;
   hexFillOpacity: number;
   gridOpacity: number;
 
@@ -297,6 +302,7 @@ export const DEFAULT_CAMPAIGN_SETTINGS: CampaignSettings = {
   showTerrainColors: true,
   showGrid: true,
   showCoordinates: true,
+  showLinkIndicators: true,
   hexFillOpacity: 0.5,
   gridOpacity: 0.3,
   availableTags: [], // User-defined tags only


### PR DESCRIPTION
Allow users to attach labeled URLs to hexes for linking to external resources (Notion, World Anvil, etc.). Links appear in the Campaign tab as clickable labels that open in new tabs.

- Add links field to HexCampaignData (Record<string, string>)
- Add Links section to HexDetailPanel with add/edit/delete UI
- Add link indicator (🔗) on map for hexes with links
- Add toggleable "Link Indicators" setting in Settings panel