### PR TITLE
Add Vercel Web Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "campaign-mapper",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "campaign-mapper",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
+        "@vercel/analytics": "^1.6.1",
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
       },
@@ -1201,6 +1202,44 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "vite": "^6.0.0"
   },
   "dependencies": {
+    "@vercel/analytics": "^1.6.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { Analytics } from '@vercel/analytics/react';
 import type {
   CampaignMap,
   HexCoord,
@@ -858,6 +859,7 @@ function App() {
           </div>
         </div>
       )}
+      <Analytics />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add Vercel Web Analytics to track usage patterns

## Changes
- Install `@vercel/analytics` package
- Add Analytics component to App.tsx

## Test plan
- [ ] Deploy to Vercel
- [ ] Verify analytics appear in Vercel dashboard